### PR TITLE
Speed-up Genomic Benchmarks dataloader

### DIFF
--- a/src/dataloaders/datasets/genomic_bench_dataset.py
+++ b/src/dataloaders/datasets/genomic_bench_dataset.py
@@ -166,7 +166,7 @@ class GenomicBenchmarkDataset(torch.utils.data.Dataset):
         # use Path object
         base_path = Path(dest_path) / dataset_name / split
 
-        self.all_paths = []
+        self.all_seqs = []
         self.all_labels = []
         label_mapper = {}
 
@@ -174,18 +174,17 @@ class GenomicBenchmarkDataset(torch.utils.data.Dataset):
             label_mapper[x.stem] = i
 
         for label_type in label_mapper.keys():
-            for x in (base_path / label_type).iterdir():
-                self.all_paths.append(x)
+            for path in (base_path / label_type).iterdir():
+                with open(path, "r") as f:
+                    content = f.read()
+                self.all_seqs.append(content)
                 self.all_labels.append(label_mapper[label_type])
-
+                
     def __len__(self):
-        return len(self.all_paths)
+        return len(self.all_labels)
 
     def __getitem__(self, idx):
-        txt_path = self.all_paths[idx]
-        with open(txt_path, "r") as f:
-            content = f.read()
-        x = content
+        x = self.all_seqs[idx]
         y = self.all_labels[idx]
 
         # apply rc_aug here if using


### PR DESCRIPTION
I've modified the dataset class such that sequences are simply stored in a list and indexed from memory rather than being read from file. With this change I observed a speedup in epoch time of up to ~ 5x

| Dataset                             | Epoch time (old) | Epoch time (new) |
|-------------------------------------|------------------|------------------|
|   dummy_mouse_enhancers_ensembl     |   3s             |   2s             |
|   human_enhancers_cohn              |   42s            |   14s            |
|   human_nontata_promoters           |   49s            |   10s            |
|   demo_coding_vs_intergenomic_seqs  |   2m 6s          |   25s            |
|   demo_human_or_worm                |   2m 19s         |   25s            |
|   human_enhancers_ensembl           |   3m 56s         |   1m 20s         |
|   human_ocr_ensembl                 |   4m 48s         |   1m 32s         |
|   human_ensembl_regulatory          |   8m 21s         |   2m 37s         |