### PR TITLE
Fix moving torchmetrics to cuda device 0

### DIFF
--- a/src/tasks/tasks.py
+++ b/src/tasks/tasks.py
@@ -63,15 +63,15 @@ class BaseTask:
 
         for name in self.torchmetric_names:
             if name in tm_mine:
-                tracked_torchmetrics[name] = tm_mine[name]().to('cuda')
+                tracked_torchmetrics[name] = tm_mine[name]()
             elif name in ['AUROC', 'StatScores', 'Precision', 'Recall', 'F1', 'F1Score']:
-                tracked_torchmetrics[name] = getattr(tm, name)(average='macro', num_classes=self.dataset.d_output, compute_on_step=False).to('cuda')
+                tracked_torchmetrics[name] = getattr(tm, name)(average='macro', num_classes=self.dataset.d_output, compute_on_step=False)
             elif '@' in name:
                 k = int(name.split('@')[1])
                 mname = name.split('@')[0]
-                tracked_torchmetrics[name] = getattr(tm, mname)(average='macro', num_classes=self.dataset.d_output, compute_on_step=False, top_k=k).to('cuda')
+                tracked_torchmetrics[name] = getattr(tm, mname)(average='macro', num_classes=self.dataset.d_output, compute_on_step=False, top_k=k)
             else:
-                tracked_torchmetrics[name] = getattr(tm, name)(compute_on_step=False).to('cuda')
+                tracked_torchmetrics[name] = getattr(tm, name)(compute_on_step=False)
         
         return tracked_torchmetrics
 


### PR DESCRIPTION
This PR removes `.to("cuda")` calls that cause the metric to be forcefully placed on GPU 0, causing a memory imbalance. A `torchmetrics` Metric is a `nn.Module`, and therefore it will be automatically placed on the right device when used in a LightningModule together with the Trainer.

The [best practice](https://lightning.ai/docs/pytorch/2.0.7/accelerators/accelerator_prepare.html#delete-cuda-or-to-calls) in Lightning is to not manipulate module or tensor placement unless there is a good reason for it. 