### PR TITLE
BUG: Using Path.iterdir() for classification labels

### DIFF
--- a/src/dataloaders/datasets/genomic_bench_dataset.py
+++ b/src/dataloaders/datasets/genomic_bench_dataset.py
@@ -169,7 +169,7 @@ class GenomicBenchmarkDataset(torch.utils.data.Dataset):
         self.all_labels = []
         label_mapper = {}
 
-        for i, x in enumerate(base_path.iterdir()):
+        for i, x in enumerate(sorted(base_path.iterdir())):
             label_mapper[x.stem] = i
 
         for label_type in label_mapper.keys():

--- a/src/dataloaders/datasets/icl_genomics_dataset.py
+++ b/src/dataloaders/datasets/icl_genomics_dataset.py
@@ -93,7 +93,7 @@ class ICLGenomicsDataset(torch.utils.data.Dataset):
         self.all_labels = []
         label_mapper = {}
 
-        for i, x in enumerate(base_path.iterdir()):
+        for i, x in enumerate(sorted(base_path.iterdir())):
             label_mapper[x.stem] = i
 
         for label_type in label_mapper.keys():


### PR DESCRIPTION
Path.iterdir() yields paths in an arbitrary order so it needs to be sorted when using it to assign labels for a classifier.

I got burned by this when repurposing the `GenomicBenchmarkDataset` class for my own data sets. We had to swap the positive and negative samples in the test data for them to get the correct classification labels! This PR fixes that.